### PR TITLE
Fix edge case in deep percolation (fixes #26)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+1.0.2 (2020-04-08)
+------------------
+
+- Fixed an issue when there was (unreasonably) large irrigation.
+
 1.0.1 (2020-04-03)
 ------------------
 

--- a/docs/swb.rst
+++ b/docs/swb.rst
@@ -205,10 +205,11 @@ between total and net irrigation; it accepts net irrigation as input
 The **deep percolation** is zero if we are at or below field capacity.
 If we are above field capacity (|θ_fc| < θ < |θ_s|) it is this:
 
-   |DP_i| = (|θ_s| - |θ_fc|) * |Z_r| / `draintime`
+   |DP_i| = (θ - |θ_fc|) * |Z_r| / `draintime`
 
-(i.e. if we need `draintime` days to go from |θ_s| to |θ_fc|, then each
-day we lose 1/`draintime` of that amount)
+If θ > |θ_s| (which technically can't happen, but θ can have this value
+as calculated in the previous step, notably if there has been too much
+irrigation) then |θ_s| is used instead of θ in the above equation.
 
 
 Reference

--- a/swb/swb.py
+++ b/swb/swb.py
@@ -97,9 +97,10 @@ class SoilWaterBalance(object):
         return max(result, 0)
 
     def dp(self, theta_prev, peff):
-        theta_prev_mm = theta_prev * self.zr * self.zr_factor
+        theta = min(theta_prev, self.theta_s)
+        theta_mm = theta * self.zr * self.zr_factor
         theta_fc_mm = self.theta_fc * self.zr * self.zr_factor
-        excess_water = theta_prev_mm - theta_fc_mm + peff
+        excess_water = theta_mm - theta_fc_mm + peff
         return max(excess_water, 0) / self.draintime
 
     def dr_without_irrig(self, dr_prev, theta_prev, ks, row):

--- a/tests/test_swb.py
+++ b/tests/test_swb.py
@@ -291,3 +291,25 @@ class ModelRunWithDrOutsideLimitsTestCase(TestCase):
     def test_dr1(self):
         """Test that Dr cannot exceed TAW."""
         self.assertAlmostEqual(self.df.iloc[0]["dr"], self.taw)
+
+
+class DpTestCase(TestCase):
+    def setUp(self):
+        self.swb = SoilWaterBalance(
+            theta_s=0.425,
+            theta_fc=0.287,
+            theta_wp=0.14,
+            zr=0.5,
+            zr_factor=1000,
+            p=0.5,
+            draintime=16.3,
+            timeseries=None,
+            theta_init=0.15,
+            mif=1.0,
+        )
+
+    def test_dp_when_theta_less_than_theta_s(self):
+        self.assertAlmostEqual(self.swb.dp(0.4, 20.0), 4.69325153)
+
+    def test_dp_when_theta_more_than_theta_s(self):
+        self.assertAlmostEqual(self.swb.dp(0.5, 20.0), 5.46012270)


### PR DESCRIPTION
When calculating deep percolation, we now use min(theta_prev, theta_s)
instead of merely theta_prev.